### PR TITLE
Made page funny again

### DIFF
--- a/ModAssistantPlus/Pages/Intro.xaml
+++ b/ModAssistantPlus/Pages/Intro.xaml
@@ -49,7 +49,7 @@
 		</TextBlock>
 
 		<TextBlock Grid.Row="8" Margin="0,5" FontSize="16" TextWrapping="Wrap">
-			If I keep seeing people leave negative reviews <Italic>because</Italic> mods broke, <LineBreak/><Bold>I will personally kill mods with a rusty frying pan with no remorse</Bold>
+			If I keep seeing people leave negative reviews <Italic>because</Italic> mods broke, <LineBreak/><Bold>I will personally kill mods with a rusty spoon with no remorse</Bold>
 		</TextBlock>
 
 		<TextBlock Grid.Row="9" Margin="0,5" FontSize="16" TextWrapping="Wrap">


### PR DESCRIPTION
A rusty frying pan isn't funny, A spoon is actually funny because it's hard to kill someone with a spoon and if they survive they'll need a tetanus shot. A frying pan is a blunt weapon and the fact that it's rusty doesn't change it's effectiveness.